### PR TITLE
Add system include path for librdkafka.

### DIFF
--- a/kafka-client.cabal
+++ b/kafka-client.cabal
@@ -52,6 +52,7 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall 
   include-dirs:        /usr/local/include/librdkafka
+                     , /usr/include/librdkafka
   extra-lib-dirs:      /usr/local/lib
   extra-libraries:     rdkafka
 


### PR DESCRIPTION
I'm using Debian unstable so the version of librdkafka is high enough for me to use but the header file wasn't found as the cabal file has the header path set to `/usr/local` instead of `/usr`.

This patch simply adds `/usr`. I'm a complete Haskell newb so I'm not sure if this approach works but it seems to. I did have a look to see if there's a better way of doing it but I couldn't find anything.